### PR TITLE
fix: webhook validation

### DIFF
--- a/pkg/handlers/webhook.go
+++ b/pkg/handlers/webhook.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/hmac"
 	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -34,7 +33,8 @@ func isValidSignature(secret string, signature string, body []byte) (bool, error
 	}
 
 	digest := mac.Sum(nil)
-	return hex.EncodeToString(digest) == signature, nil
+	actual := fmt.Sprintf("sha256=%x", digest)
+	return actual == signature, nil
 }
 
 type route struct {
@@ -192,7 +192,7 @@ func WebhookHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	signature := strings.TrimLeft(r.Header.Get("X-Hub-Signature-256"), "sha256=")
+	signature := r.Header.Get("X-Hub-Signature-256")
 	if signature == "" {
 		errorResponse(w, r, fmt.Errorf("signature header not found"), http.StatusBadRequest)
 		return

--- a/pkg/handlers/webhook_test.go
+++ b/pkg/handlers/webhook_test.go
@@ -8,8 +8,20 @@ import (
 
 func TestValidSignature(t *testing.T) {
 	// echo -n "data" | openssl dgst -sha256 -hmac secret
-	signature := "1b2c16b75bd2a870c114153ccda5bcfca63314bc722fa160d690de133ccbb9db"
+	signature := "sha256=1b2c16b75bd2a870c114153ccda5bcfca63314bc722fa160d690de133ccbb9db"
 	result, err := isValidSignature("secret", signature, []byte("data"))
+
+	assert.Nil(t, err)
+	assert.True(t, result)
+}
+
+func TestValidSignatureWithLeadingsha256Chars(t *testing.T) {
+	// TrimLeft was previously used to strip sha256= from the Signature header
+	// This caused a bug because all characters from sha256= were being stripped in the
+	// prefix, i.e. sigs starting with a would have that stripped
+	// echo -n "data1" | openssl dgst -sha256 -hmac secret
+	signature := "sha256=adbf386f8df2776192df3c30026d3bd19f01bff25dd0bfa10852caea9bc4759c"
+	result, err := isValidSignature("secret", signature, []byte("data1"))
 
 	assert.Nil(t, err)
 	assert.True(t, result)
@@ -46,7 +58,7 @@ func TestRouteParseMultiple(t *testing.T) {
 	assert.Equal(t, "event2", routes[1].events[0])
 }
 
-func TestRouteParseInvaid(t *testing.T) {
+func TestRouteParseInvalid(t *testing.T) {
 	envVars := []string{
 		"RULE_TEST=event|address|jq rule",
 		"RULE_FOO=event|address",


### PR DESCRIPTION
webhook validation trimmed 'sha256=', but this trims all characters
in the set, rarther than the specific prefix. Updated to work around
this issue